### PR TITLE
FIX: build option of build.sh / UBUNTU_VER -> BUILD_UBUNTU

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -6,13 +6,14 @@ set -e
 
 ## arguments as environment variables
 # BUILD_ROS [ noetic ] or humble
+# BUILD_UBUNTU [ optional ] or 20.04, 22.04, 24.04
 # REPO [repo.irsl.eiiris.tut.ac.jp/]
 # INPUT_IMAGE [ ${REPO}irsl_base:${BUILD_ROS}_nvidia ]
 # NO_CACHE [ '' ]
 
 ## noetic or melodic
 ROS_DISTRO_=${BUILD_ROS:-"noetic"}
-CUR_UBUNTU=${UBUNTU_VER:-""}
+CUR_UBUNTU=${BUILD_UBUNTU:-""}
 if [ ${ROS_DISTRO_} == "humble" ]; then
     if [ -z "${CUR_UBUNTU}" ]; then
         CUR_UBUNTU="22.04"


### PR DESCRIPTION
This pull request includes a small change to the `build.sh` script. The change introduces a new environment variable `BUILD_UBUNTU` to specify the Ubuntu version, replacing the previously used `UBUNTU_VER` variable.

* [`build.sh`](diffhunk://#diff-4d2a8eefdf2a9783512a35da4dc7676a66404b6f3826a8af9aad038722da6823R9-R16): Added `BUILD_UBUNTU` environment variable to specify Ubuntu version, replacing `UBUNTU_VER`.