### PR TITLE
devcontainer環境中のPYTHONPATH削除

### DIFF
--- a/.devcontainer/run_cpu/docker-compose.yml
+++ b/.devcontainer/run_cpu/docker-compose.yml
@@ -4,7 +4,6 @@ services:
     docker_irsl_system_nogpu:
         image: repo.irsl.eiiris.tut.ac.jp/irsl_system:noetic
         environment:
-            - PYTHONPATH=/choreonoid_ws/install/lib/python3/dist-packages:/opt/ros/noetic/lib/python3/dist-packages:/choreonoid_ws/install/lib/choreonoid-2.3/python:/userdir
             - DOCKER_ROS_SETUP=/choreonoid_ws/install/setup.bash
             - ROS_IP=localhost
             - ROS_MASTER_URI=http://localhost:11311

--- a/.devcontainer/run_gpu/docker-compose.yml
+++ b/.devcontainer/run_gpu/docker-compose.yml
@@ -4,7 +4,6 @@ services:
     docker_irsl_system_nvidia:
         image: repo.irsl.eiiris.tut.ac.jp/irsl_system:noetic
         environment:
-            - PYTHONPATH=/choreonoid_ws/install/lib/python3/dist-packages:/opt/ros/noetic/lib/python3/dist-packages:/choreonoid_ws/install/lib/choreonoid-2.3/python:/userdir
             - DOCKER_ROS_SETUP=/choreonoid_ws/install/setup.bash
             - ROS_IP=localhost
             - ROS_MASTER_URI=http://localhost:11311


### PR DESCRIPTION
Relayed to https://github.com/IRSL-tut/irsl_docker_irsl_system/pull/52#issuecomment-2814399602

Devcontinerの勉強中に設定していたPYTHONPATHが残っていたので削除．