### PR TITLE
add irsl_python_lib

### DIFF
--- a/Dockerfile.build_system.vcstool
+++ b/Dockerfile.build_system.vcstool
@@ -56,6 +56,9 @@ cat <<- _DOC_ >> dot.rosinstall
 - git:    
     local-name: irsl_raspi_controller
     uri: https://github.com/IRSL-tut/irsl_raspi_controller.git
+- git:    
+    local-name: irsl_python_lib
+    uri: https://github.com/IRSL-tut/irsl_python_lib.git    
 ### IRSL settings <<< ###
 _DOC_
 EOF
@@ -111,7 +114,7 @@ RUN  mkdir -p /ros_home/.jupyter/lab/user-settings/\@jupyterlab/completer-extens
 
 ENV PATH=$PATH:/user_scripts
 ENV JUPYTER_PATH=/jupyter
-ENV PYTHONPATH=/choreonoid_ws/install/lib/choreonoid-${CNOID_VERSION}/python
+ENV PYTHONPATH=/choreonoid_ws/install/lib/choreonoid-${CNOID_VERSION}/python:/choreonoid_ws/src/irsl_python_lib
 
 ### [HOTFIX]
 RUN if [ -e /choreonoid_ws/install/share/choreonoid-${CNOID_VERSION}/robot_assembler/irsl ]; then  rm -rf /choreonoid_ws/install/share/choreonoid-${CNOID_VERSION}/robot_assembler/irsl; fi && \

--- a/files/run_docker_main.sh
+++ b/files/run_docker_main.sh
@@ -34,7 +34,9 @@ if [ -n "$USE_USER" ]; then
     USER_SETTING=" -u $(id -u):$(id -g) -v /etc/passwd:/etc/passwd:ro -v /etc/group:/etc/group:ro"
 fi
 
-_ROS_IP=${ARG_ROS_IP:-"localhost"}
+
+_ROS_IP=${ARG_ROS_IP:-"0.0.0.0"}
+_ROS_HOSTNAME=${ARG_ROS_HOSTNAME:-"localhost"}
 _ROS_MASTER_URI=${ARG_ROS_MASTER_URI:-"http://localhost:11311"}
 
 ##xhost +local:root
@@ -54,6 +56,7 @@ docker run \
     ${DOCKER_ENVIRONMENT_VAR} \
     --env="DOCKER_ROS_SETUP=${_ROS_SETUP}" \
     --env="ROS_IP=${_ROS_IP}" \
+    --env="ROS_HOSTNAME=${_ROS_HOSTNAME}" \
     --env="ROS_MASTER_URI=${_ROS_MASTER_URI}" \
     --env="DISPLAY"  \
     --env="QT_X11_NO_MITSHM=1" \

--- a/run.sh
+++ b/run.sh
@@ -19,6 +19,7 @@ _REPO="repo.irsl.eiiris.tut.ac.jp/"
 MOUNT_OPTION=""
 _DOCKER_OPT=""
 _ROS_IP=
+_ROS_HOSTNAME=
 _ROS_MASTER_URI=
 
 while [[ $# -gt 0 ]]; do
@@ -105,6 +106,11 @@ while [[ $# -gt 0 ]]; do
             shift
             shift
             ;;
+        --ros-hostname)
+            _ROS_HOSTNAME="$2"
+            shift
+            shift
+            ;;
         --ros-master-uri)
             _ROS_MASTER_URI="$2"
             shift
@@ -188,6 +194,7 @@ OPT=$OPT \
 NO_GPU=$_NO_GPU \
 USE_USER=$_USE_USER \
 ARG_ROS_IP=${_ROS_IP} \
+ARG_ROS_HOSTNAME=${_ROS_HOSTNAME} \
 ARG_ROS_MASTER_URI=${_ROS_MASTER_URI} \
 DOCKER_OPTION="${MOUNT_OPTION} ${_DOCKER_OPT}" \
 ${abs_dir}/files/run_docker_main.sh \


### PR DESCRIPTION
This pull request introduces several changes to enhance functionality and improve configurability in the Docker-based build system. The most important changes include adding a new dependency (`irsl_python_lib`), extending the Python path, and introducing support for the `ROS_HOSTNAME` environment variable across multiple scripts.

### Dependency and environment updates:

* Added a new Git repository dependency (`irsl_python_lib`) to the `dot.rosinstall` file in `Dockerfile.build_system.vcstool`.
* Updated the `PYTHONPATH` environment variable in `Dockerfile.build_system.vcstool` to include the `irsl_python_lib` directory.

### ROS environment variable enhancements:

* Introduced the `ROS_HOSTNAME` environment variable in `files/run_docker_main.sh`, with a default value of `"localhost"`.
* Passed the `ROS_HOSTNAME` variable to the Docker container as an environment variable in `files/run_docker_main.sh`.
* Added support for the `--ros-hostname` command-line argument in `run.sh`, allowing users to specify the `ROS_HOSTNAME` value.
* Propagated the `ROS_HOSTNAME` argument to the Docker script invocation in `run.sh`.