### PR TITLE
texlive-xetexの追加

### DIFF
--- a/Dockerfile.add_xeus
+++ b/Dockerfile.add_xeus
@@ -32,7 +32,7 @@ RUN apt update -q -qq && \
 
 ## python related install
 RUN apt update -q -qq && \
-    apt install -q -qq -y python3-pip && \
+    apt install -q -qq -y python3-pip texlive-xetex && \
     apt clean && \
     rm -rf /var/lib/apt/lists/ && \
     if [ "$(lsb_release -s -r)" = "24.04" ]; then \


### PR DESCRIPTION
jupyter-notebookにおいて「File -> Save and Export Notebook as -> PDF」と操作したときに，texlive-xetexがないためエラーとなる．その対策のためにtexlive-xetexを追加する．